### PR TITLE
Add UIAvatar and UIAvatarGroup helpers

### DIFF
--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -1,0 +1,39 @@
+module AvatarHelper
+  def UIAvatar(options = {})
+    fallbackColor = options[:fallbackColor] || 'navy'
+    fallbackInitials = options[:fallbackInitials] || nil
+    size = options[:size] || 'medium'
+    name = options[:name] || nil
+    isGrouped = options[:isGrouped] || false
+
+    avatarImage = content_tag(:span, '', class: "ui-avatar__avatar", style: "background-image: url(#{options[:src]})").html_safe
+
+    content_tag(:span,
+      avatarImage,
+      'aria-label': name,
+      'data-fallback-initials': fallbackInitials,
+      class: "ui-avatar ui-avatar--#{size} ui-avatar--fallback-#{fallbackColor} #{isGrouped && 'ui-avatar--grouped'}",
+      role: 'img'
+    ).html_safe
+  end
+
+  def UIAvatarGroup(options = {})
+    chipSize = options[:avatars] ? options[:avatars].last[:size] : nil
+    overflowChip = content_tag(:span,
+      options[:overflow],
+      class: "ui-avatar-group__chip ui-avatar--#{chipSize}",
+    ).html_safe
+
+     if (options[:avatars])
+      content_tag(:div, :nil, class: "ui-avatar-group" ) {
+        options[:avatars].each do |avatar|
+          avatar[:isGrouped] = true
+          concat UIAvatar(avatar)
+        end
+        concat overflowChip
+      }.html_safe
+    end
+
+  end
+  
+end


### PR DESCRIPTION
Adds some basic view helpers to display avatars and avatar groups with the appropriate class names from UI.

**Usage:**

```erb
<%= UIAvatar(
  src: "https://pbs.twimg.com/profile_images/1108388041968758785/rj_3dXd9_200x200.jpg",
  name: "Alex Pate",
  fallbackInitials: 'AP',
  fallbackColor: 'orange',
  size: 'large'
) %>

<%= UIAvatarGroup(
  overflow: 9,
  avatars: [
    {
      fallbackInitials: 'AP',
      name: "Alex Pate",
      fallbackColor: 'orange',
      size: 'medium'
    },
    {
      fallbackInitials: 'AP',
      name: "Alex Pate",
      fallbackColor: 'navy',
      size: 'medium'
    },
    {
      fallbackInitials: 'AP',
      name: "Alex Pate",
      fallbackColor: 'pink',
      size: 'medium'
    },
    {
      fallbackInitials: 'AP',
      name: "Alex Pate",
      fallbackColor: 'orange',
      size: 'medium'
    }
  ]
) %>
```