### PR TITLE
Remove reference to MIT-LICENSE file, MIT license

### DIFF
--- a/kalo-ui_helpers.gemspec
+++ b/kalo-ui_helpers.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/kalohq/kalo-ui-helpers"
   s.summary = "Shared Kalo Rails helpers"
   s.description = "A set of shared helpers, styles, and other assets for our Rails projects"
-  s.license = "MIT"
+  s.licenses = ["Nonstandard"]
+  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
 
-  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", "~> 5.2.1"
   s.add_development_dependency "rspec-rails"


### PR DESCRIPTION
- This repo does not contain a file `MIT-LICENSE`
- This repo is closed-source and private

So:

- Do not include that file in allowed gem files
- Do not mention MIT as license for the gem, use the special word which raises no warning "Nonstandard"